### PR TITLE
Update CH5 to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,10 @@
         "": {
             "name": "ch5-webpack",
             "version": "1.0.0",
-            "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
-                "@crestron/ch5-crcomlib": "2.5.0",
-                "@crestron/ch5-webxpanel": "2.5.0",
+                "@crestron/ch5-crcomlib": "2.6.1",
+                "@crestron/ch5-webxpanel": "2.6.1",
                 "patch-package": "^8.0.0"
             },
             "devDependencies": {
@@ -37,26 +36,27 @@
             }
         },
         "node_modules/@crestron/ch5-crcomlib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@crestron/ch5-crcomlib/-/ch5-crcomlib-2.5.0.tgz",
-            "integrity": "sha512-R6qwEWxId749ruoNgI9byazXxDy7/J1rGPh64vKOUc48PlvSn+zVA94an2H2Lok312zKI5BE5Y+Oz1J1B/vmQQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@crestron/ch5-crcomlib/-/ch5-crcomlib-2.6.1.tgz",
+            "integrity": "sha512-hYttpWgLzZzDBivh0QgTITJXMuxFdmc7voySrU6RJA4PQTRdhAE4KeYM0aJmjGVg9p1g/oZTvoRXO41507TKnQ==",
             "dependencies": {
                 "@raghavendradabbir/mycolorpicker": "^1.0.0",
                 "axios": "^0.21.1",
                 "hammerjs": "^2.0.8",
                 "i18next": "^21.6.3",
+                "lodash": "^4.17.21",
                 "nouislider": "^15.5.0",
                 "rxjs": "^7.3.0",
                 "swiper": "^7.3.1"
             },
             "engines": {
-                "node": ">=16.13.0"
+                "node": ">=20.4.0"
             }
         },
         "node_modules/@crestron/ch5-webxpanel": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@crestron/ch5-webxpanel/-/ch5-webxpanel-2.5.0.tgz",
-            "integrity": "sha512-iiiN/Wj0vxFItIGYC7CloBPJDAtGciI6wlcGuIJ0aBCe4evQxcku8oo5kZIw6RJ0IBruP+oNHh1rZhcU26MruA=="
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@crestron/ch5-webxpanel/-/ch5-webxpanel-2.6.1.tgz",
+            "integrity": "sha512-6YxTH+QEXXI7lvq3NdFuGmOIzC/RlwTf0P2NxtTEp/xTysRii/zWe0ExGXtUOQlnb+FeiteIYWH0bUvMRY8utg=="
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
@@ -2477,8 +2477,7 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lower-case": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
         "webpack-dev-server": "^4.15.1"
     },
     "dependencies": {
-        "@crestron/ch5-crcomlib": "2.5.0",
-        "@crestron/ch5-webxpanel": "2.5.0",
+        "@crestron/ch5-crcomlib": "2.6.1",
+        "@crestron/ch5-webxpanel": "2.6.1",
         "patch-package": "^8.0.0"
     }
 }

--- a/patches/@crestron+ch5-crcomlib+2.6.1.patch
+++ b/patches/@crestron+ch5-crcomlib+2.6.1.patch
@@ -1,14 +1,14 @@
 diff --git a/node_modules/@crestron/ch5-crcomlib/package.json b/node_modules/@crestron/ch5-crcomlib/package.json
-index 87b6f7c..ea05a4a 100644
+index 6d3e5a1..2505349 100644
 --- a/node_modules/@crestron/ch5-crcomlib/package.json
 +++ b/node_modules/@crestron/ch5-crcomlib/package.json
 @@ -10,7 +10,8 @@
-         "ch5",
+         "ch5", 
          "CrComLib"
-     ],
+     ], 
 -    "types": "build_bundles/umd/@types/index.d.ts", 
-+    "types": "build_bundles/cjs/@types/index.d.ts",
 +    "main": "build_bundles/cjs/cr-com-lib.js",
++    "types": "build_bundles/cjs/@types/index.d.ts", 
      "scripts": {
-         "build:ci:dev:amd": "cross-env NODE_ENV=dev MODULE_TYPE=amd CI=true webpack --progress --config=webpack.dev.config.js",
-         "build:ci:dev:cjs": "cross-env NODE_ENV=dev MODULE_TYPE=cjs CI=true webpack --progress --config=webpack.dev.config.js",
+         "build:ci:dev:amd": "cross-env NODE_ENV=dev MODULE_TYPE=amd CI=true webpack --progress --config=webpack.dev.config.js", 
+         "build:ci:dev:cjs": "cross-env NODE_ENV=dev MODULE_TYPE=cjs CI=true webpack --progress --config=webpack.dev.config.js", 

--- a/patches/@crestron+ch5-webxpanel+2.6.1.patch
+++ b/patches/@crestron+ch5-webxpanel+2.6.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@crestron/ch5-webxpanel/package.json b/node_modules/@crestron/ch5-webxpanel/package.json
+index 296ba87..db1f3fe 100644
+--- a/node_modules/@crestron/ch5-webxpanel/package.json
++++ b/node_modules/@crestron/ch5-webxpanel/package.json
+@@ -6,7 +6,7 @@
+         "type": "git",
+         "url": "https://github.com/CrestronEng/CH5VirtualPanel.git"
+     },
+-    "main": "dist/umd/index.js",
++    "main": "dist/cjs/index.js",
+     "license": "SEE LICENSE IN LICENSE.txt",
+     "scripts": {
+         "build": "npm run build:cjs && npm run build:umd && npm run build:amd",

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,39 @@
-import * as CrComLib from "@crestron/ch5-crcomlib";
-import * as WebXPanel from "@crestron/ch5-webxpanel";
-import './styles/main.scss'
+import CrComLib from "@crestron/ch5-crcomlib";
+import { getWebXPanel, runsInContainerApp } from "@crestron/ch5-webxpanel";
+import './styles/main.scss';
 
-import { bridgeReceiveIntegerFromNative, bridgeReceiveBooleanFromNative, bridgeReceiveStringFromNative, bridgeReceiveObjectFromNative }
-from "@crestron/ch5-crcomlib";
-window.CrComLib = CrComLib; //need this for xpanel subscribeState to work
-window["bridgeReceiveIntegerFromNative"] = bridgeReceiveIntegerFromNative;
-window["bridgeReceiveBooleanFromNative"] = bridgeReceiveBooleanFromNative;
-window["bridgeReceiveStringFromNative"] = bridgeReceiveStringFromNative;
-window["bridgeReceiveObjectFromNative"] = bridgeReceiveObjectFromNative;
+CrComLib = CrComLib.CrComLib; // Re-assign CrComLib local variable to the CrComLib.CrComLib object that exists in 2.6+
+window.CrComLib = CrComLib; // Assign this CrComLib local variable to the Window object for WebXPanel access
+
+window.bridgeReceiveIntegerFromNative = CrComLib.bridgeReceiveIntegerFromNative;
+window.bridgeReceiveBooleanFromNative = CrComLib.bridgeReceiveBooleanFromNative;
+window.bridgeReceiveStringFromNative = CrComLib.bridgeReceiveStringFromNative;
+window.bridgeReceiveObjectFromNative = CrComLib.bridgeReceiveObjectFromNative;
+
+const { WebXPanel, isActive, WebXPanelConfigParams, WebXPanelEvents, getVersion, getBuildDate } = getWebXPanel(!runsInContainerApp());
 
 //Web Xpanel
 const configuration = {
-    host: "192.168.1.218",
-    ipId: "0x42"
+    host: "192.168.1.223",
+    ipId: "0x04"
 }
 
-if (WebXPanel.isActive) {
+if (isActive) {
 
-    console.log(`WebXPanel version: ${WebXPanel.getVersion()}`);
-    console.log(`WebXPanel build date: ${WebXPanel.getBuildDate()}`);
+    console.log(`WebXPanel version: ${getVersion()}`);
+    console.log(`WebXPanel build date: ${getBuildDate()}`);
 
-    WebXPanel.default.initialize(configuration);
-    WebXPanel.default.addEventListener(WebXPanel.WebXPanelEvents.CONNECT_CIP, ({ detail }) => {
+    WebXPanel.initialize(configuration);
+
+    window.addEventListener(WebXPanelEvents.CONNECT_CIP, ({ detail }) => {
         const { url, ipId, roomId } = detail;
         console.log(`Connected to ${url}, 0x${ ipId.toString(16)}, ${roomId}`);
     });
-    WebXPanel.default.addEventListener(WebXPanel.WebXPanelEvents.DISCONNECT_CIP, ({ detail }) => {
+    window.addEventListener(WebXPanelEvents.DISCONNECT_CIP, ({ detail }) => {
         const { reason } = detail;
         console.log(`Disconnected from CIP. Reason: ${reason}`);
     });
 }
-
-
 
 // Basic Example of a single button
 const button = document.getElementById("hello");
@@ -40,11 +41,11 @@ const button = document.getElementById("hello");
 button.addEventListener("click", function() {
     CrComLib.publishEvent("b", "1", true);
     CrComLib.publishEvent("b", "1", false);
-});  
+}); 
 
 
-CrComLib.subscribeState("b",  "1",   (value)  =>  {         
-    if  (value)  {       button.classList.add("demo--selected");          }        
-    else  {             button.classList.remove("demo--selected");         }            
-});   
-document.getElementById("hello").click();  
+CrComLib.subscribeState("b", "1",  (value) => {
+    if (value) { button.classList.add("demo--selected"); }
+    else { button.classList.remove("demo--selected"); }
+});
+document.getElementById("hello").click();


### PR DESCRIPTION
Adjustments had to be made to the import syntax (especially in regards to WebXPanel) and modifications to the package.json for both CrComLib and WebXPanel (specifically to reference CJS as module type) for an update to CH5 2.6.1 to work.